### PR TITLE
Implement escape sequence in the EventInterrupt

### DIFF
--- a/interrupt.go
+++ b/interrupt.go
@@ -23,11 +23,16 @@ import (
 type EventInterrupt struct {
 	t time.Time
 	v interface{}
+        esc string
 }
 
 // When returns the time when this event was created.
 func (ev *EventInterrupt) When() time.Time {
 	return ev.t
+}
+
+func (ev *EventInterrupt) EscSeq() string {
+	return ev.esc
 }
 
 // Data is used to obtain the opaque event payload.


### PR DESCRIPTION
 An interface Event in event.go has new function named EscSeq() since upstream commit 869faf86 for store the escape sequence in the event. However, this change did not apply to EventInterrupt. This patch adds EscSeq() to EventInterrupt for implementing its interface.

Signed-off-by: Jongmin Kim <jmkim@pukyong.ac.kr>