### PR TITLE
fix: WheelDown should not be mapped to Button2

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -936,7 +936,7 @@ func (t *tScreen) postMouseEvent(x, y, btn int, motion bool) {
 		if !t.wasbtn {
 			button = WheelDown
 		} else {
-			button = Button2
+			button = Button1
 		}
 	}
 


### PR DESCRIPTION
When using micro editor with tmux in termux, swipe up gesture destroyes a document.

It happens because:

1. termux send swipe up gesture as button down and wheel-down event.
2. tmux seems to consume the button down event.
3. tcell convert wheel-down events into Button2.
4. micro maps Button2 to paste.
