### PR TITLE
console_win: Try VIRTUAL_TERMINAL_PROCESSING aka modeVtOutput first and switch to alternate screen processing

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -146,6 +146,8 @@ const (
 	vtSetBg      = "\x1b[48;5;%dm"
 	vtSetFgRGB   = "\x1b[38;2;%d;%d;%dm" // RGB
 	vtSetBgRGB   = "\x1b[48;2;%d;%d;%dm" // RGB
+	vtEnterCA    = "\x1b[?1049h\x1b[22;0;0t" // activate alternate screen + store title
+	vtExitCA     = "\x1b[?1049l\x1b[23;0;0t" // deactivate alternate screen + restore title
 )
 
 // NewConsoleScreen returns a Screen for the Windows console associated
@@ -225,6 +227,10 @@ func (s *cScreen) Init() error {
 		s.setOutMode(0)
 	}
 
+	if s.vten {
+		s.emitVtString(vtEnterCA)
+	}
+
 	s.clearScreen(s.style)
 	s.hideCursor()
 	s.Unlock()
@@ -251,6 +257,10 @@ func (s *cScreen) Fini() {
 }
 
 func (s *cScreen) finish() {
+	if s.vten {
+		s.emitVtString(vtExitCA)
+	}
+
 	s.Lock()
 	s.style = StyleDefault
 	s.curx = -1

--- a/console_win.go
+++ b/console_win.go
@@ -215,19 +215,13 @@ func (s *cScreen) Init() error {
 
 	s.fini = false
 	s.setInMode(modeResizeEn | modeExtndFlg)
-
-	// 24-bit color is opt-in for now, because we can't figure out
-	// to make it work consistently.
-	if s.truecolor {
-		s.setOutMode(modeVtOutput | modeNoAutoNL | modeCookedOut)
-		var omode uint32
-		s.getOutMode(&omode)
-		if omode&modeVtOutput == modeVtOutput {
-			s.vten = true
-		} else {
-			s.truecolor = false
-		}
+	s.setOutMode(modeVtOutput | modeNoAutoNL | modeCookedOut)
+	var omode uint32
+	s.getOutMode(&omode)
+	if omode&modeVtOutput == modeVtOutput {
+		s.vten = true
 	} else {
+		s.truecolor = false
 		s.setOutMode(0)
 	}
 


### PR DESCRIPTION
According to @DHowett (maintainer for the Windows Console subsystem and the Terminal)...

> In my opinion, all applications should use `VIRTUAL_TERMINAL_PROCESSING` mode _first_ and only fall back to the legacy ways if they need to!

...so we should try to activate modeVtOutput regardless if `truecolor` is set or not and switch then into the alternate screen mode (ported from `tscreen` and terminfo of `xterm`). Only then we can fix the ugly effect reported with the issue this PR tries to solve. With the change I wasn't able to reproduce this under Windows any longer.

Still something is happening with the terminal style when `micro` is closed:
- The Windows Terminal prompt then still uses the background color of `micro`, till the screen is `clear`ed.
- The previous history isn't available any longer.

Fixes zyedidia/micro#3073

@gdamore
This is most probably something which can/should be considered upstream too.

PS:
@zyedidia & @gdamore
Maybe there is a chance to bundle the competence and efforts again upstream so `micro` doesn't need to rely on his own fork any longer. Just my thoughts. :wink: 